### PR TITLE
Clarify section 5.3 requirements

### DIFF
--- a/rootstore/policy.md
+++ b/rootstore/policy.md
@@ -1,6 +1,6 @@
 # Mozilla Root Store Policy #
 
-*Version 2.6*
+*Version 2.6.1*
 
 *[Effective July 1, 2018][Policy-Archive]*
 
@@ -456,14 +456,13 @@ refers to any organization or legal entity that is in possession
 or control of a certificate that is capable of being used to
 issue new certificates.
 
-Intermediate certificates created after January 1, 2019:
+These requirements include all cross-certificates which chain to a certificate 
+that is included in Mozilla’s CA Certificate Program.
+
+Intermediate certificates created after January 1, 2019, with the exception of cross-certificates that share a private key with a corresponding root certificate:
 *   MUST contain an EKU extension; and,
 *   MUST NOT include the anyExtendedKeyUsage KeyPurposeId; and,
 *   MUST NOT include both the id-kp-serverAuth and id-kp-emailProtection KeyPurposeIds in the same certificate.
-
-These requirements include all cross-certified certificates
-which chain to a certificate that is included in Mozilla’s CA
-Certificate Program.
 
 #### 5.3.1 Technically Constrained ####
 


### PR DESCRIPTION
Clarify that the new requirement for intermediate certificates to be limited to either serverAuth or emailProtection does not apply to cross certificates. Change existing "cross-certified certificate" language to "cross-certificates".