### PR TITLE
Disclose also TCSC to CCADB

### DIFF
--- a/rootstore/policy.md
+++ b/rootstore/policy.md
@@ -625,7 +625,9 @@ A certificate is deemed to directly or transitively chain to a CA certificate in
 (1)	the certificate's Issuer Distinguished Name matches (according to the name-matching algorithm specified in RFC 5280, section 7.1) the Subject Distinguished Name in a CA certificate or intermediate certificate that is in scope according to section 1.1 of this Policy, and
 (2)	the certificate is signed with a Private Key whose corresponding Public Key is encoded in the SubjectPublicKeyInfo of that CA certificate or intermediate certificate.
 
-Thus, the operator of a CA certificate trusted in Mozilla’s CA Certificate Program MUST disclose in the CCADB all non-technically constrained CA certificates they issue that chain up to that CA certificate trusted in Mozilla’s CA Certificate Program. This applies to all non-technically constrained CA certificates, including those that share the same key pair whether they are self-signed, doppelgänger, reissued, cross-signed, or other roots.
+Thus, the operator of a CA certificate trusted in Mozilla’s CA Certificate Program MUST disclose in the CCADB all CA certificates they issue that chain up to that CA certificate trusted in Mozilla’s CA Certificate Program. This applies to all CA certificates, including those that share the same key pair whether they are self-signed, doppelgänger, reissued, cross-signed, or other roots.
+
+Technically constraint CA certificates which were exempted from being disclosed in previous versions of this policy MUST be filed subsequently to CCADB until XXXXX.
 
 The term "subordinate CA" in this section
 refers to any organization or legal entity that is in possession


### PR DESCRIPTION
As discussed on the list (https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/XsVpyOGlagE/m/xw8JGJYZBAAJ) it seems to be reasonable to require also technically constraint sub CAs to be disclosed to CCADB if they chain up to a root in Mozilla's root store.