### PR TITLE
Clarifying trust transfer

### DIFF
--- a/rootstore/policy.md
+++ b/rootstore/policy.md
@@ -882,7 +882,7 @@ relevant news or government organizations such as US-CERT.
 
 ## 8. CA Operational Changes ##
 
-CAs SHOULD NOT assume that trust is transferable. All CAs whose certificates
+CAs SHALL NOT assume that trust is transferable. All CAs whose certificates
 are included in Mozilla's root program MUST [notify Mozilla][Email-Us] if:
 
 * ownership or control of the CA’s certificate(s) changes, or


### PR DESCRIPTION
It is just a single change, but I think the current wording "SHOULD NOT assume" is not what you want to say. In fact, it should be written "SHALL  NOT assume". The new wording still allows the transfer of trust but makes clear, that nobody has a right to expect, that trust can be transferred.