### PR TITLE
Merge proposed v.3.0 changes into Master version

### DIFF
--- a/rootstore/policy.md
+++ b/rootstore/policy.md
@@ -719,7 +719,7 @@ Mozilla’s goal is to ensure that revocation occurs as swiftly as possible whil
 To ensure compliance with the TLS BRs, Mozilla requires that CA operators:
 * engage in proactive communication and advise subscribers well in advance about the revocation timelines and explicitly warn them against using publicly-trusted TLS server certificates on systems that cannot tolerate timely revocation;
 * include appropriate language in customer agreements requiring subscribers’ timely cooperation in meeting revocation timelines and acknowledging the CA’s obligations to adhere to applicable policies and standards;
-*  prepare and maintain comprehensive and actionable plans to address mass revocation events, including detailed procedures for handling mass revocations effectively, including rapid communication with affected parties and conducting annual plan testing; and
+*  prepare and maintain comprehensive and actionable plans to address mass revocation events, including detailed procedures for handling mass revocations effectively, including rapid communication with affected parties and conducting annual plan testing through tabletop exercises, simulations, parallel testing, or use of test environments, which do not involve the revocation of active certificates; and
 * engage a third party assessor to evaluate whether the CA Operator has:
      * well-documented and actionable plans to handle mass revocation events;
      * demonstrated the implementation and feasibility of the plans through testing exercises, including documentation of testing processes, timelines, results, and remediation steps; and


### PR DESCRIPTION
This PR merges the finalized version 3.0 changes into the master branch. 

Key changes include:

- **No Exceptions to Revocation Requirements** – Explicitly states that Mozilla does not grant exceptions to TLS Baseline Requirements for revocation, ensuring more consistent enforcement.
- **Stronger Subscriber Communication & Contractual Clarity** – Requires CAs to inform subscribers about timely revocation risks and mandates contractual obligations for compliance.
- **Mass Revocation Preparedness** – CAs must develop, test, and maintain plans for large-scale certificate revocation, validated by independent assessors.
- **Automation in Certificate Issuance & Renewal** – Requires new root CAs to offer automation for DCV, issuance, and renewal, with public transparency through CCADB.
- **Phasing Out Dual-Purpose Root CAs** – New root certificates must be dedicated to TLS or S/MIME; existing dual-purpose roots must transition by December 2028.
- **Strengthening CA Key Security ("Cradle-to-Grave" Monitoring)** – Implements stricter key lifecycle tracking, requiring audit reporting of "parked" key public hashes.

All changes have been reviewed and are ready for final integration. Please let me know if any additional adjustments are needed before merging.